### PR TITLE
Set the composer type to phpcodesniffer-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "moxio/php-codesniffer-sniffs",
+    "type": "phpcodesniffer-standard",
     "description": "Custom sniffs for PHP_CodeSniffer",
     "license": "MIT",
     "keywords" : [ "phpcs", "PHP_CodeSniffer", "sniffs", "standards" ],


### PR DESCRIPTION
Setting the composer type to "phpcodesniffer-standard" will allow  [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer) to automagically detect the standard for usage.