### PR TITLE
Allow PHP 8 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "squizlabs/php_codesniffer": "^3.0.0",
         "slevomat/coding-standard": "^5.0 || ^6.0"
     },


### PR DESCRIPTION
Allows projects to install this library when running on PHP8. Should I add it to `.travis.yml` too?