### PR TITLE
Bump slevomat dependency to allow 8.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "squizlabs/php_codesniffer": "^3.0.0",
-        "slevomat/coding-standard": "^6.0 || ^7.0 || ^8.0 <= 8.1.0"
+        "slevomat/coding-standard": "^6.0 || ^7.0 || ^8.0 <= 8.6.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.12"


### PR DESCRIPTION
As there are no significant changes to the used helpers, keep updating the upper limit

https://github.com/slevomat/coding-standard/compare/8.1.0...8.6.2