### PR TITLE
Bump slevomat dependency to allow 8.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "squizlabs/php_codesniffer": "^3.0.0",
-        "slevomat/coding-standard": "^6.0 || ^7.0 || ^8.0 <= 8.6.2"
+        "slevomat/coding-standard": "^6.0 || ^7.0 || ^8.0 <= 8.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.12"


### PR DESCRIPTION
Update requirements to allow the latest version of slevomat. mainly because of this change 
https://github.com/slevomat/coding-standard/commit/fbc18cfa65673edc41e31db97934ca03930530cd