### PR TITLE
Add sniff detecting date create from format with formats with unspecified time component

### DIFF
--- a/MoxioSniffs/Sniffs/PHP/DisallowDateCreateFromFormatWithUnspecifiedTimeComponent.php
+++ b/MoxioSniffs/Sniffs/PHP/DisallowDateCreateFromFormatWithUnspecifiedTimeComponent.php
@@ -1,0 +1,51 @@
+<?php
+namespace Moxio\CodeSniffer\MoxioSniffs\Sniffs\PHP;
+
+use Moxio\CodeSniffer\MoxioSniffs\Sniffs\AbstractFunctionCallSniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowDateCreateFromFormatWithUnspecifiedTimeComponent extends AbstractFunctionCallSniff
+{
+	private const TIME_COMPONENTS = 'ghGHisvu';
+
+	public $supportedTokenizers = [
+		'PHP',
+	];
+
+	public function registerFunctions(): array
+	{
+		return [
+			'\DateTime::createFromFormat',
+			'\DateTimeImmutable::createFromFormat',
+			'date_create_from_format',
+			'date_create_immutable_from_format',
+		];
+	}
+
+	protected function processFunctionCall(File $phpcsFile, $functionName, $functionNamePtr, $argumentPtrs)
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		if (count($argumentPtrs) > 0) {
+			$formatArgumentStart = $argumentPtrs[0]['start'];
+			$formatArgumentEnd = $argumentPtrs[0]['end'];
+			if ($formatArgumentStart !== $formatArgumentEnd || $tokens[$formatArgumentStart]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+				return;
+			}
+
+			$format = substr($tokens[$formatArgumentStart]['content'], 1, -1);
+			if (self::formatContainsTimeComponent($format) === false && $format[0] !== '!' && $format[-1] !== '|') {
+				$phpcsFile->addError('Date creation formats without a time component should be initialized to null.', $formatArgumentStart, 'ArgumentNotTrue');
+			}
+		}
+	}
+
+	private static function formatContainsTimeComponent(string $format): bool {
+		for ($i = 0; $i < strlen(self::TIME_COMPONENTS); $i++) {
+			if (strpos($format, self::TIME_COMPONENTS[$i]) !== false) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/MoxioSniffs/Sniffs/Tests/PHP/DisallowDateCreateFromFormatWithUnspecifiedTimeComponentTest.inc
+++ b/MoxioSniffs/Sniffs/Tests/PHP/DisallowDateCreateFromFormatWithUnspecifiedTimeComponentTest.inc
@@ -1,0 +1,37 @@
+<?php
+DateTime::createFromFormat('Y-m-d', '2022-03-04');
+DateTime::createFromFormat('!Y-m-d', '2022-03-04');
+DateTime::createFromFormat('Y-m-d|', '2022-03-04');
+DateTime::createFromFormat('Y-m-d H:i:s', '2022-03-04 12:13:14');
+\DateTime::createFromFormat('Y-m-d', '2022-03-04');
+\DateTime::createFromFormat('!Y-m-d', '2022-03-04');
+\DateTime::createFromFormat('Y-m-d|', '2022-03-04');
+\DateTime::createFromFormat('Y-m-d H:i:s', '2022-03-04 12:13:14');
+DateTimeImmutable::createFromFormat('Y-m-d', '2022-03-04');
+DateTimeImmutable::createFromFormat('!Y-m-d', '2022-03-04');
+DateTimeImmutable::createFromFormat('Y-m-d|', '2022-03-04');
+DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2022-03-04 12:13:14');
+\DateTimeImmutable::createFromFormat('Y-m-d', '2022-03-04');
+\DateTimeImmutable::createFromFormat('!Y-m-d', '2022-03-04');
+\DateTimeImmutable::createFromFormat('Y-m-d|', '2022-03-04');
+\DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2022-03-04 12:13:14');
+date_create_from_format('Y-m-d', '2022-03-04');
+date_create_from_format('!Y-m-d', '2022-03-04');
+date_create_from_format('Y-m-d|', '2022-03-04');
+date_create_from_format('Y-m-d H:i:s', '2022-03-04 12:13:14');
+date_create_immutable_from_format('Y-m-d', '2022-03-04');
+date_create_immutable_from_format('!Y-m-d', '2022-03-04');
+date_create_immutable_from_format('Y-m-d|', '2022-03-04');
+date_create_immutable_from_format('Y-m-d H:i:s', '2022-03-04 12:13:14');
+
+DateTime::createFromFormat('!Y-m-d H:i:s', '2022-03-04 12:13:14');
+DateTime::createFromFormat('Y-m-d H:i:s|', '2022-03-04 12:13:14');
+DateTime::createFromFormat('!Y-m-d|', '2022-03-04');
+DateTime::createFromFormat('Y-m-d g', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d h', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d G', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d H', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d i', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d s', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d v', '2022-03-04 12');
+DateTime::createFromFormat('Y-m-d u', '2022-03-04 12');

--- a/MoxioSniffs/Sniffs/Tests/PHP/DisallowDateCreateFromFormatWithUnspecifiedTimeComponentTest.php
+++ b/MoxioSniffs/Sniffs/Tests/PHP/DisallowDateCreateFromFormatWithUnspecifiedTimeComponentTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Moxio\CodeSniffer\MoxioSniffs\Sniffs\Tests\PHP;
+
+use Moxio\CodeSniffer\MoxioSniffs\Sniffs\PHP\DisallowDateCreateFromFormatWithUnspecifiedTimeComponent;
+use Moxio\CodeSniffer\MoxioSniffs\Sniffs\Tests\AbstractSniffTest;
+
+class DisallowDateCreateFromFormatWithUnspecifiedTimeComponentTest extends AbstractSniffTest {
+	protected function getSniffClass()
+	{
+		return DisallowDateCreateFromFormatWithUnspecifiedTimeComponent::class;
+	}
+
+	public function testSniff()
+	{
+		$file = __DIR__ . '/DisallowDateCreateFromFormatWithUnspecifiedTimeComponentTest.inc';
+		$this->assertFileHasErrorsOnLines($file, [
+			2,
+			6,
+			10,
+			14,
+			18,
+			22,
+		]);
+	}
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Moxio PHP_CodeSniffer sniffs
 =============================
-This is a collection of our custom PHP_Codesniffer (3.x) sniffs for detecting potential bugs 
+This is a collection of our custom PHP_Codesniffer (3.x) sniffs for detecting potential bugs
 and unexpected behavior in PHP code. It may be used as a ruleset on its own, but it is mainly
 intended as a set of separate sniffs that can be integrated into other standards.
 
@@ -25,35 +25,35 @@ Description of sniffs
 _More sniffs will be added soon._
 
 **MoxioSniffs.PHP.DisallowBareContinueInSwitch**: Disallows the `continue` statement without a numeric
-argument when used directly within a `switch`-`case`. This prevents silent bugs caused by PHP 
+argument when used directly within a `switch`-`case`. This prevents silent bugs caused by PHP
 considering `switch` [to be a looping structure](http://php.net/manual/en/control-structures.switch.php).
 
 **MoxioSniffs.PHP.DisallowImplicitLooseComparison**: Disallows implicit non-strict comparisons by functions
 like `in_array` and `array_search`. Requires that the `$strict`-parameter to these functions is
-explicitly set. This prevents hidden bugs due to [counter-intuitive behavior of non-strict 
+explicitly set. This prevents hidden bugs due to [counter-intuitive behavior of non-strict
 comparison](https://twitter.com/fabpot/status/460707769990266880).
 
 **MoxioSniffs.PHP.DisallowImplicitLooseBase64Decode**: Disallows implicit non-strict usage of the `base64_decode` function.
 Requires that the `$strict`-parameter to this function is explicitly set.
 
-**MoxioSniffs.PHP.DisallowUniqidWithoutMoreEntropy**: Disallows calls to `uniqid()` without `$more_entropy = 
-true`.  When `$more_entropy` is `false` (which is the default), `uniqid()` calls `usleep()` to avoid 
+**MoxioSniffs.PHP.DisallowUniqidWithoutMoreEntropy**: Disallows calls to `uniqid()` without `$more_entropy =
+true`.  When `$more_entropy` is `false` (which is the default), `uniqid()` calls `usleep()` to avoid
 collisions, which [can be a substantial performance hit](http://blog.kevingomez.fr/til/2015/07/26/why-is-uniqid-slow/).
 Always calling `uniqid()` with `$more_entropy = true` avoids these problems.
 
 **MoxioSniffs.PHP.DisallowArrayCombinersWithSingleArray**: Disallows calls to functions that combine two or more
-arrays with only a single array given as an argument. This applies to functions like `array_merge(_recursive)`, 
+arrays with only a single array given as an argument. This applies to functions like `array_merge(_recursive)`,
 `array_replace(_recursive)` and all variants of `array_diff` and `array_intersect`. Such a call does not make sense,
 and is most likely a result of a misplaced comma or parenthesis. To re-index a single array, just use `array_values`.
 
-**MoxioSniffs.PHP.DisallowImplicitMicrotimeAsString**: Disallows calls to `microtime()` without the `$get_as_float` 
+**MoxioSniffs.PHP.DisallowImplicitMicrotimeAsString**: Disallows calls to `microtime()` without the `$get_as_float`
 argument being explicitly set. By default, `microtime` has a string as its return value ("msec sec"), which
-is unexpected and cannot be naively cast to float, making it error-prone. It is still possible to set this 
+is unexpected and cannot be naively cast to float, making it error-prone. It is still possible to set this
 argument to `false`, but in that case you have probably thought about this.
 
 **MoxioSniffs.PHP.DisallowImplicitIteratorToArrayWithUseKeys**: Disallows calls to `iterator_to_array()` without the
 `$use_keys` argument being explicitly set. By default, `iterator_to_array` uses the keys provided
-by the iterator. This behavior is often desired for associative arrays, but can cause [unexpected 
+by the iterator. This behavior is often desired for associative arrays, but can cause [unexpected
 results](https://twitter.com/hollodotme/status/1057909890566537217) for 'list-like' arrays. Explicitly
 requiring the parameter to be set ensures that the developer has to think about which behavior is desired
 for the situation at hand.
@@ -66,12 +66,18 @@ for more background on why you would want to discourage using `\DateTime`.
 name that implies it can actually detect the encoding of a string, a problem which is generally impossible. Rather
 it checks a list of encodings until it finds one that _could_ be the right one (i.e. the string is a valid byte sequence
 according to that encoding). Using `mb_check_encoding` (possibly in a loop) instead makes this much more explicit. See
-[this talk](https://www.youtube.com/watch?v=K2zS6vbBb9A) for more background information on this topic. 
+[this talk](https://www.youtube.com/watch?v=K2zS6vbBb9A) for more background information on this topic.
 
-**MoxioSniffs.PHP.DisallowUtf8EncodeDecode**: Disallows calls to `utf8_encode()` and `utf8_decode()`. These functions 
-can be considered misleading because they only convert to/from ISO-8859-1, and do not 'magically' detect the 
-source/target encoding. Using `iconv()` or `mb_convert_encoding()` instead makes both character encodings that play a 
+**MoxioSniffs.PHP.DisallowUtf8EncodeDecode**: Disallows calls to `utf8_encode()` and `utf8_decode()`. These functions
+can be considered misleading because they only convert to/from ISO-8859-1, and do not 'magically' detect the
+source/target encoding. Using `iconv()` or `mb_convert_encoding()` instead makes both character encodings that play a
 role in the conversion explicit.
+
+**MoxioSniffs.PHP.DisallowDateCreateFromFormatWithUnspecifiedTimeComponent**: Disallows calls to
+`\DateTime::createFromFormat`, `\DateTimeImmutable::createFromFormat`, `date_create_from_format` &
+`date_create_immutable_from_format` with formats which do not specify a time component and do not initialize fields to
+null. This would otherwise create DateTime(Immutable) objects with a time component set to the current (creation) time,
+which is probably never what you want and can be a source of bugs.
 
 Running tests
 -------------
@@ -87,7 +93,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Please note that, from the perspective of this library as a pick-and-match collection of sniffs (and not
 a complete coding standard), the addition of new sniffs will not be considered a breaking change and thus
-does not cause an increase in the major version number.  
+does not cause an increase in the major version number.
 
 License
 -------


### PR DESCRIPTION
This prevents DateTime objects used as simple dates (without time component) from being initialized with the current time.