### PR TITLE
Update slevomat/coding-standard to allow versions up to v8.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,22 @@ jobs:
 
         strategy:
             matrix:
-                php-version: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
+                php-version:
+                    - 7.3  # from 2018-12 to 2020-12 (2021-12)
+                    - 7.4  # from 2019-11 to 2021-11 (2022-11)
+                    - 8.0  # from 2020-11 to 2022-11 (2023-11)
+                    - 8.1  # from 2021-11 to 2023-11 (2025-12)
+                    - 8.2  # from 2022-12 to 2024-12 (2026-12)
+                    - 8.3  # from 2023-11 to 2025-12 (2027-12)
+                    - 8.4  # from 2024-11 to 2026-12 (2028-12)
+                    - 8.5  # from 2025-11 to 2027-12 (2029-12)
+
+        # Prevent unsupported versions of PHP to fail the CI run
+        continue-on-error: ${{ contains(fromJson('[ "7.3", "7.4", "8.0", "8.1", "8.2" ]'), matrix.php-version) == false }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "squizlabs/php_codesniffer": "^3.0.0",
-        "slevomat/coding-standard": "^6.0 || ^7.0 || ^8.0 <= 8.15.0"
+        "slevomat/coding-standard": "^6.0 || ^7.0 || ^8.0 <= 8.20.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.12"


### PR DESCRIPTION
Currently, the highest version of `slevomat/coding-standard` this projects supports is `8.15` (released 2024-03-09).

Since then, newer versions have been release. The most notable changes, beside various bugfixes, are `v8.16` (which drops supprt for PHP 7.2 and 7.3), and `v8.19` (which adds support for PHP 8.4).

This pull request updates `composer.json` to allow versions up to `v8.20`.

The CI workflow has been updated so that tests are run against newer versions of PHP.
A [`continue-on-error` entry][1] has been added to prevent the CI run from failing for currently unsupported versions.

The `actions/checkout` action is also updated to the latest version (v4).

As can be seen [in the CI run][2], the versions the CI runs are:

| PHP         | <sup>slevomat/<br>coding-standard</sup> |
| ----------- | ------------------------ |
| 7.3.33      |                   8.15.0 | 
| 7.4.33      |                   8.20.0 |
| 8.0.30      |                   8.20.0 |
| 8.1.33      |                   8.20.0 |
| 8.2.29      |                   8.20.0 |
| 8.3.23      |                   8.20.0 |
| 8.4.10      |                   8.20.0 |
| 8.5.0 (dev) |                   8.20.0 |


[1]: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontinue-on-error
[2]: https://github.com/potherca-contrib/moxio-php-codesniffer-sniffs/actions/runs/16750568701